### PR TITLE
Add daily focus stats elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,6 +317,22 @@
                                         <div class="stat-label">Blocs Obligatoires</div>
                                     </div>
                                 </div>
+
+                                <div class="stat-card purple">
+                                    <div class="stat-icon">⚡</div>
+                                    <div class="stat-content">
+                                        <div class="stat-value" id="dailyFocusXP">0</div>
+                                        <div class="stat-label">XP Focus</div>
+                                    </div>
+                                </div>
+
+                                <div class="stat-card purple">
+                                    <div class="stat-icon">🔥</div>
+                                    <div class="stat-content">
+                                        <div class="stat-value" id="focusStreak">0</div>
+                                        <div class="stat-label">Streak Focus</div>
+                                    </div>
+                                </div>
                             </div>
 
                             <!-- Statut des blocs amélioré -->
@@ -337,6 +353,12 @@
                                         <div class="block-indicator"></div>
                                         <span class="block-label">Bonus</span>
                                         <span class="block-xp">+10 XP</span>
+                                    </div>
+                                    <div class="daily-progress">
+                                        <div class="progress-label">Progression Sessions</div>
+                                        <div class="progress-bar-daily">
+                                            <div class="progress-fill-daily" id="dailyProgressFill"></div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- add missing daily focus stat elements to dashboard
- include progress bar for focus session completion

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6878026474308332b520a0cf0118ca87