### PR TITLE
Fix mismatched streak ID

### DIFF
--- a/script.js
+++ b/script.js
@@ -382,7 +382,7 @@ class MyRPGLife {
         document.getElementById('dailySessions').textContent = this.data.dailyFocusStats.sessions;
         document.getElementById('dailyFocusTime').textContent = `${Math.round(this.data.dailyFocusStats.totalTime)}min`;
         document.getElementById('dailyFocusXP').textContent = this.data.dailyFocusStats.totalXP;
-        document.getElementById('focusStreak').textContent = this.data.dailyFocusStats.streak;
+        document.getElementById('streakDays').textContent = this.data.dailyFocusStats.streak;
         
         // Mettre à jour la barre de progression (objectif: 2 sessions)
         const progressPercent = Math.min(100, (this.data.dailyFocusStats.sessions / 2) * 100);


### PR DESCRIPTION
## Summary
- correct streak display by using `streakDays` id everywhere

## Testing
- `node test_streak.js` *(fails: cannot set properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_6878026596408332a5d7e0edeeee14f0